### PR TITLE
fix sidebar for server browser search

### DIFF
--- a/lua/menu_plugins/modules/sidebar.lua
+++ b/lua/menu_plugins/modules/sidebar.lua
@@ -52,8 +52,10 @@ function PANEL:Think()
 
 	if self.hovered then
 		self:Moove(IN)
+		self:SetKeyboardInputEnabled(true)
 	elseif not self.hovered then
 		self:Moove(OUT)
+		self:SetKeyboardInputEnabled(false)
 	end
 end
 


### PR DESCRIPTION
keyboard input was being trapped by the sidebar, so remove it when we don't need it